### PR TITLE
Fix argument of Loader function in examples

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -1,6 +1,6 @@
 var loader, Loader, things, thing
 
 Loader  = require('../').Loader
-loader  = new Loader(__dirname + '/things');
+loader  = new Loader(__dirname);
 things  = loader.load().things;
 thing   = new things.Thing("db thing");


### PR DESCRIPTION
line 4 in examples/index.js cause syntax error
```
thing   = new things.Thing("db thing");
                    ^
TypeError: Cannot read property 'Thing' of undefined
```